### PR TITLE
release: style adjustments and improvements

### DIFF
--- a/src/components/DefaultPage/DefaultPage.tsx
+++ b/src/components/DefaultPage/DefaultPage.tsx
@@ -13,7 +13,7 @@ function DefaultPage({
 
   // Stars are near-white on the dark background and a soft teal on light, so the
   // effect reads on both themes without washing out the foreground text.
-  const starColor = theme === 'dark' ? '#8fa39c' : '#0f7a63';
+  const starColor = theme === 'dark' ? '#0f7a63' : '#000000';
 
   return (
     <HtmlTag className={className}>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -41,7 +41,7 @@ function Footer() {
       <div className='my-5 border-t border-line dark:border-line-dark' />
       <div className='grid w-full grid-cols-1 items-start gap-8 px-4 py-5 sm:grid-cols-3'>
         <div className='flex flex-col items-start gap-3'>
-          <h3 className='text-sm font-semibold text-muted dark:text-muted-dark'>
+          <h3 className='text-md font-semibold text-muted dark:text-muted-dark'>
             {t('footer.connect')}
           </h3>
           {connectItems.map(item => (
@@ -58,7 +58,7 @@ function Footer() {
         </div>
 
         <div className='flex flex-col items-start gap-3'>
-          <h3 className='text-sm font-semibold text-muted dark:text-muted-dark'>
+          <h3 className='text-md font-semibold text-muted dark:text-muted-dark'>
             {t('footer.getInTouch')}
           </h3>
           <span className='font-mono text-sm'>+55 (81) 98438-8381</span>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { BiMailSend, BiSolidFileArchive } from 'react-icons/bi';
 import { CONTACT_EMAIL, CV_URL } from '../../constants';
-import Link from '../Link/Link';
 
 function Footer() {
   const { t } = useTranslation();
@@ -23,11 +22,18 @@ function Footer() {
   ];
 
   const actionButtonClass = clsx(
-    'flex w-full items-center gap-2 rounded-md p-2 font-semibold',
+    'flex w-full items-center justify-center gap-2 rounded-md px-3 py-2.5 font-semibold leading-none',
     'border border-line bg-accent/10 text-ink',
     'dark:border-line-dark dark:bg-white/5 dark:text-ink-dark',
     'shadow-sm transition-all duration-300 ease-out',
     'hover:scale-[1.03] hover:text-accent dark:hover:text-accent-dark',
+  );
+
+  const connectLinkClass = clsx(
+    'font-mono text-sm',
+    'text-ink hover:text-accent',
+    'dark:text-ink-dark dark:hover:text-accent-dark',
+    'transition-colors duration-300 ease-out hover:underline',
   );
 
   return (
@@ -39,9 +45,15 @@ function Footer() {
             {t('footer.connect')}
           </h3>
           {connectItems.map(item => (
-            <Link key={item.name} to={item.url} variant='link' external>
+            <a
+              key={item.name}
+              href={item.url}
+              target='_blank'
+              rel='noopener noreferrer'
+              className={connectLinkClass}
+            >
               {item.name}
-            </Link>
+            </a>
           ))}
         </div>
 

--- a/src/components/Starfield/Starfield.tsx
+++ b/src/components/Starfield/Starfield.tsx
@@ -23,7 +23,7 @@ function Starfield({
     <div
       aria-hidden='true'
       className={clsx(
-        'pointer-events-none fixed left-0 top-0 -z-10 h-full w-full select-none overflow-hidden opacity-60',
+        'pointer-events-none fixed left-0 top-0 -z-10 h-full w-full select-none overflow-hidden opacity-100',
         className,
       )}
     >

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -100,7 +100,7 @@ export const PLATFORM_AND_DEVOPS: Array<TechnologyCardProps> = [
 export const PROJECTS: Array<ProjectCardProps> = [
   {
     id: 'homelab',
-    name: 'Homelab',
+    name: 'HomeLab',
     githubRepoUrl: 'https://github.com/mateuseap/homelab',
     deployedAppUrl: 'https://homelab.mateuseap.com',
     technologiesUsed: [


### PR DESCRIPTION
Release of the portfolio fixes from develop into main (deploys to [www.mateuseap.com](http://www.mateuseap.com/) via gh-pages).

Includes: Footer texts and buttons adjustments, starfield background visualization improvement and project name adjustment. See https://github.com/mateuseap/mateuseap.github.io/pull/44.