### PR TITLE
feat: add Mixtape project card and fix project/tech card spacing

### DIFF
--- a/src/assets/mixtape-icon.svg
+++ b/src/assets/mixtape-icon.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Mixtape: MP3 player with a clickable 3D wheel">
+  <rect width="64" height="64" rx="15" fill="#0c1a14" />
+  <circle cx="32" cy="32" r="17" fill="none" stroke="#35d0a5" stroke-width="3" />
+  <circle cx="32" cy="32" r="7" fill="#35d0a5" />
+  <circle cx="32" cy="15" r="2.6" fill="#35d0a5" />
+  <circle cx="32" cy="49" r="2.6" fill="#35d0a5" />
+  <circle cx="15" cy="32" r="2.6" fill="#35d0a5" />
+  <circle cx="49" cy="32" r="2.6" fill="#35d0a5" />
+</svg>

--- a/src/components/TechnologyCard/TechnologyCard.tsx
+++ b/src/components/TechnologyCard/TechnologyCard.tsx
@@ -6,7 +6,7 @@ function TechnologyCard({ name, Icon = undefined }: TechnologyCardProps) {
     <div
       className={clsx(
         'flex flex-col items-center justify-center space-y-2 font-semibold',
-        'rounded-md border p-4 text-sm shadow-sm',
+        'min-h-[88px] rounded-md border p-4 text-sm shadow-sm',
         'border-line bg-black/[0.02] text-ink',
         'dark:border-line-dark dark:bg-white/5 dark:text-ink-dark',
         'hover:border-accent/60 hover:text-accent active:translate-y-[2px]',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -43,6 +43,7 @@ import avatar from '../assets/avatar.jpg';
 import homelabIcon from '../assets/homelab-icon.svg';
 import chesskernelIcon from '../assets/chesskernel-icon.svg';
 import pixelhubIcon from '../assets/pixelhub-icon.svg';
+import mixtapeIcon from '../assets/mixtape-icon.svg';
 import type { TechnologyCardProps, ProjectCardProps } from '../types';
 
 export const PROFILE_PICTURE_URL = avatar;
@@ -135,6 +136,14 @@ export const PROJECTS: Array<ProjectCardProps> = [
     deployedAppUrl: 'https://pixelhub.lab.mateuseap.com',
     technologiesUsed: ['Phaser', 'Colyseus', 'LiveKit'],
     thumbnail: pixelhubIcon,
+  },
+  {
+    id: 'mixtape',
+    name: 'Mixtape',
+    githubRepoUrl: 'https://github.com/mateuseap/mixtape',
+    deployedAppUrl: 'https://mixtape.lab.mateuseap.com',
+    technologiesUsed: ['Node.js', 'Express', 'Three.js', 'SQLite'],
+    thumbnail: mixtapeIcon,
   },
   {
     id: 'oncase',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -26,6 +26,7 @@
       "homelab": "Self-hosted GitOps platform running k3s on a single VPS, with declarative ArgoCD deployments and end-to-end observability.",
       "chesskernel": "Real-time multiplayer chess platform with live games, matchmaking and Stockfish-powered analysis.",
       "pixelhub": "Gather-style 2D virtual world where players move around a map and talk through proximity-based voice chat.",
+      "mixtape": "An open, no-login MP3 jukebox with an interactive 3D click-wheel player, built with Three.js and a Node.js/Express backend.",
       "2048": "My rendition of the classic single-player sliding tile puzzle game.",
       "chess": "The classic chess game, built from scratch in Python.",
       "festalab": "A user management dashboard with registration, editing, deletion, listing, pagination and search.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -26,6 +26,7 @@
       "homelab": "Plataforma GitOps autoalojada que ejecuta k3s en un único VPS, con despliegues declarativos mediante ArgoCD y observabilidad completa.",
       "chesskernel": "Plataforma de ajedrez multijugador en tiempo real con partidas en vivo, emparejamiento y análisis con Stockfish.",
       "pixelhub": "Mundo virtual 2D al estilo Gather, donde los jugadores se mueven por el mapa y hablan mediante chat de voz por proximidad.",
+      "mixtape": "Una jukebox de MP3 abierta y sin inicio de sesión, con un reproductor 3D de rueda de clics interactiva, construida con Three.js y un backend en Node.js/Express.",
       "2048": "Mi versión del clásico juego de rompecabezas de deslizar fichas para un jugador.",
       "chess": "El clásico juego de ajedrez, construido desde cero en Python.",
       "festalab": "Un panel de gestión de usuarios con registro, edición, eliminación, listado, paginación y búsqueda.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -26,6 +26,7 @@
       "homelab": "Plataforma GitOps auto-hospedada rodando k3s em um único VPS, com deploys declarativos via ArgoCD e observabilidade completa.",
       "chesskernel": "Plataforma de xadrez multiplayer em tempo real com partidas ao vivo, matchmaking e análise com o Stockfish.",
       "pixelhub": "Mundo virtual 2D no estilo Gather, onde os jogadores se movem pelo mapa e conversam por voz baseada em proximidade.",
+      "mixtape": "Uma jukebox de MP3 aberta e sem login, com um player 3D de roda de cliques interativa, construída com Three.js e um backend em Node.js/Express.",
       "2048": "Minha versão do clássico jogo de quebra-cabeça de deslizar blocos para um jogador.",
       "chess": "O clássico jogo de xadrez, construído do zero em Python.",
       "festalab": "Um painel de gerenciamento de usuários com cadastro, edição, exclusão, listagem, paginação e busca.",

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -102,7 +102,7 @@ function Home() {
 
         <section className='mt-2'>
           <h2 className='text-xl font-semibold'>{t('projects.title')}</h2>
-          <div className='mt-5 grid grid-cols-1 gap-3'>
+          <div className='mt-5 grid grid-cols-1 gap-5'>
             {PROJECTS.map(project => (
               <ProjectCard
                 key={project.id}


### PR DESCRIPTION
## Summary

- Add the Mixtape project (open, no-login MP3 jukebox with a 3D click-wheel player built in Three.js, Node.js/Express backend, SQLite storage) to the projects list, positioned right below PixelHub. Adds the icon import and translated descriptions (en, pt-BR, es) to match the existing project-card convention.
- Increase the gap between project cards from `gap-3` to `gap-5` so the spacing reads as intentional rather than cramped.
- Fix uneven tech-card row heights on the mobile skills grid: `TechnologyCard` now reserves a consistent `min-h-[88px]` so rows without an icon (C, C++) no longer render shorter than icon-bearing sibling rows.

## Test plan

- [x] `npm run build` compiles with no errors
- [x] Verified in dev server that the Mixtape card renders directly below PixelHub with its icon showing correctly
- [x] Verified the increased project-card gap looks intentional at desktop width
- [x] Verified at a 390px mobile viewport that the C/C++ tech cards now match the height of icon-bearing sibling rows (confirmed against baseline screenshot showing the row was previously shorter)
- [x] Confirmed no em dash characters in any touched file