### PR TITLE
docs: describe mixtape as multi-device sound equipment

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -26,7 +26,7 @@
       "homelab": "Self-hosted GitOps platform running k3s on a single VPS, with declarative ArgoCD deployments and end-to-end observability.",
       "chesskernel": "Real-time multiplayer chess platform with live games, matchmaking and Stockfish-powered analysis.",
       "pixelhub": "Gather-style 2D virtual world where players move around a map and talk through proximity-based voice chat.",
-      "mixtape": "An open, no-login MP3 jukebox with an interactive 3D click-wheel player, built with Three.js and a Node.js/Express backend.",
+      "mixtape": "An open, no-login library of interactive 3D sound equipment: an MP3 click-wheel player and a CD player, built with Three.js and a Node.js/Express backend.",
       "2048": "My rendition of the classic single-player sliding tile puzzle game.",
       "chess": "The classic chess game, built from scratch in Python.",
       "festalab": "A user management dashboard with registration, editing, deletion, listing, pagination and search.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -26,7 +26,7 @@
       "homelab": "Plataforma GitOps autoalojada que ejecuta k3s en un único VPS, con despliegues declarativos mediante ArgoCD y observabilidad completa.",
       "chesskernel": "Plataforma de ajedrez multijugador en tiempo real con partidas en vivo, emparejamiento y análisis con Stockfish.",
       "pixelhub": "Mundo virtual 2D al estilo Gather, donde los jugadores se mueven por el mapa y hablan mediante chat de voz por proximidad.",
-      "mixtape": "Una jukebox de MP3 abierta y sin inicio de sesión, con un reproductor 3D de rueda de clics interactiva, construida con Three.js y un backend en Node.js/Express.",
+      "mixtape": "Una biblioteca abierta y sin inicio de sesión de equipos de sonido 3D interactivos: un reproductor MP3 de rueda de clics y un reproductor de CD, construida con Three.js y un backend en Node.js/Express.",
       "2048": "Mi versión del clásico juego de rompecabezas de deslizar fichas para un jugador.",
       "chess": "El clásico juego de ajedrez, construido desde cero en Python.",
       "festalab": "Un panel de gestión de usuarios con registro, edición, eliminación, listado, paginación y búsqueda.",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -26,7 +26,7 @@
       "homelab": "Plataforma GitOps auto-hospedada rodando k3s em um único VPS, com deploys declarativos via ArgoCD e observabilidade completa.",
       "chesskernel": "Plataforma de xadrez multiplayer em tempo real com partidas ao vivo, matchmaking e análise com o Stockfish.",
       "pixelhub": "Mundo virtual 2D no estilo Gather, onde os jogadores se movem pelo mapa e conversam por voz baseada em proximidade.",
-      "mixtape": "Uma jukebox de MP3 aberta e sem login, com um player 3D de roda de cliques interativa, construída com Three.js e um backend em Node.js/Express.",
+      "mixtape": "Uma biblioteca aberta e sem login de equipamentos de som 3D interativos: um player MP3 de roda de cliques e um CD player, construída com Three.js e um backend em Node.js/Express.",
       "2048": "Minha versão do clássico jogo de quebra-cabeça de deslizar blocos para um jogador.",
       "chess": "O clássico jogo de xadrez, construído do zero em Python.",
       "festalab": "Um painel de gerenciamento de usuários com cadastro, edição, exclusão, listagem, paginação e busca.",


### PR DESCRIPTION
## Summary
- Mixtape expanded from a single MP3 click-wheel player into a small rack of interactive 3D sound equipment (MP3 click wheel, CD player), with more devices planned.
- Update the projects.items.mixtape copy in en.json, es.json, and pt-BR.json to mention both devices.

## Test plan
- [x] node -e requiring all three locale JSON files to confirm they parse
- [x] Left src/constants/index.ts's technologiesUsed array untouched (still accurate)