### PR TITLE
fix: tighten project grid gap to match skills rhythm

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -102,7 +102,7 @@ function Home() {
 
         <section className='mt-2'>
           <h2 className='text-xl font-semibold'>{t('projects.title')}</h2>
-          <div className='mt-5 grid grid-cols-1 gap-5'>
+          <div className='mt-5 grid grid-cols-1 gap-3'>
             {PROJECTS.map(project => (
               <ProjectCard
                 key={project.id}


### PR DESCRIPTION
## Summary
- Project card grid used gap-5 while the skills/tech grids above it use gap-2, reading as visually inconsistent
- Reduced to gap-3, a middle ground that keeps the bordered cards clearly separated while following the tighter spacing rhythm used everywhere else on the page

## Test plan
- [x] Verified via headless Chrome screenshot before/after
- [x] Production build succeeds