### PR TITLE
release: tighten project grid gap

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -102,7 +102,7 @@ function Home() {
 
         <section className='mt-2'>
           <h2 className='text-xl font-semibold'>{t('projects.title')}</h2>
-          <div className='mt-5 grid grid-cols-1 gap-5'>
+          <div className='mt-5 grid grid-cols-1 gap-3'>
             {PROJECTS.map(project => (
               <ProjectCard
                 key={project.id}


### PR DESCRIPTION
## Summary
- Project card grid gap reduced from gap-5 to gap-3 to match the tighter spacing rhythm used by the skills/tech grids

## Test plan
- [x] Production build succeeds
- [x] Verified visually via headless Chrome screenshot