### PR TITLE
release: update role title to Software Engineer

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -7,7 +7,7 @@
   },
   "hero": {
     "bio": "Passionate about coding and committed to using technology to assist and empower others, I actively seek out opportunities to collaborate and innovate.",
-    "role": "Full Stack Software Engineer @ FestaLab",
+    "role": "Software Engineer",
     "education": "B.Sc. Student of Computer Science @ CIn/UFPE",
     "location": "Pernambuco, Brazil"
   },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -7,7 +7,7 @@
   },
   "hero": {
     "bio": "Apasionado por la programación y comprometido con usar la tecnología para ayudar y potenciar a los demás, busco activamente oportunidades para colaborar e innovar.",
-    "role": "Ingeniero de Software Full Stack @ FestaLab",
+    "role": "Ingeniero de Software",
     "education": "Estudiante de Ingeniería en Ciencias de la Computación @ CIn/UFPE",
     "location": "Pernambuco, Brasil"
   },

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -7,7 +7,7 @@
   },
   "hero": {
     "bio": "Apaixonado por programação e comprometido em usar a tecnologia para ajudar e capacitar outras pessoas, busco ativamente oportunidades para colaborar e inovar.",
-    "role": "Engenheiro de Software Full Stack @ FestaLab",
+    "role": "Engenheiro de Software",
     "education": "Bacharelando em Ciência da Computação @ CIn/UFPE",
     "location": "Pernambuco, Brasil"
   },


### PR DESCRIPTION
Ships the role title update from #56: the hero section now displays 'Software Engineer' instead of 'Full Stack Software Engineer @ FestaLab' across all three locales (en, pt-BR, es).