### PR TITLE
release: update page title and meta tags to Software Engineer

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,10 +18,10 @@
       })();
     </script>
 
-    <title>Mateus Elias | Full Stack Software Engineer</title>
+    <title>Mateus Elias | Software Engineer</title>
     <meta
       name="description"
-      content="Mateus Elias is a full stack software engineer building web platforms and self-hosted GitOps infrastructure with TypeScript, React, NestJS, Kubernetes and ArgoCD."
+      content="Mateus Elias is a software engineer building web platforms and self-hosted GitOps infrastructure with TypeScript, React, NestJS, Kubernetes and ArgoCD."
     />
     <meta name="author" content="Mateus Elias" />
     <link rel="canonical" href="https://www.mateuseap.com/" />
@@ -46,11 +46,11 @@
     <meta property="og:site_name" content="Mateus Elias" />
     <meta
       property="og:title"
-      content="Mateus Elias | Full Stack Software Engineer"
+      content="Mateus Elias | Software Engineer"
     />
     <meta
       property="og:description"
-      content="Full stack software engineer building web platforms and self-hosted GitOps infrastructure with TypeScript, React, NestJS, Kubernetes and ArgoCD."
+      content="Software engineer building web platforms and self-hosted GitOps infrastructure with TypeScript, React, NestJS, Kubernetes and ArgoCD."
     />
     <meta property="og:url" content="https://www.mateuseap.com/" />
     <meta
@@ -62,11 +62,11 @@
     <meta name="twitter:card" content="summary" />
     <meta
       name="twitter:title"
-      content="Mateus Elias | Full Stack Software Engineer"
+      content="Mateus Elias | Software Engineer"
     />
     <meta
       name="twitter:description"
-      content="Full stack software engineer building web platforms and self-hosted GitOps infrastructure with TypeScript, React, NestJS, Kubernetes and ArgoCD."
+      content="Software engineer building web platforms and self-hosted GitOps infrastructure with TypeScript, React, NestJS, Kubernetes and ArgoCD."
     />
     <meta
       name="twitter:image"
@@ -88,7 +88,7 @@
         "alternateName": "mateuseap",
         "url": "https://www.mateuseap.com/",
         "image": "https://avatars.githubusercontent.com/u/52019009?v=4",
-        "jobTitle": "Full Stack Software Engineer",
+        "jobTitle": "Software Engineer",
         "sameAs": [
           "https://github.com/mateuseap",
           "https://www.linkedin.com/in/mateuseliasdeandradepereira/",


### PR DESCRIPTION
Ships the page title and meta tags update from #58: the browser tab title and social previews still showed `Full Stack Software Engineer` after the hero section had been updated, and the JSON-LD structured data was also outdated.