### PR TITLE
chore: add Streamlit to tech stack and prioritize TS/JS/React/Streamlit

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -16,6 +16,7 @@ import {
   SiTraefikproxy as TraefikIcon,
   SiTerraform as TerraformIcon,
   SiGithubactions as GitHubActionsIcon,
+  SiStreamlit as StreamlitIcon,
 } from 'react-icons/si';
 import {
   TbBrandTypescript as TypeScriptIcon,
@@ -56,11 +57,11 @@ export const CV_URL =
 export const CONTACT_EMAIL = 'mateuseap@mateuseap.com';
 
 export const PROGRAMMING_LANGUAGES: Array<TechnologyCardProps> = [
+  { name: 'TypeScript', Icon: TypeScriptIcon },
+  { name: 'JavaScript', Icon: JavascriptIcon },
+  { name: 'Python', Icon: PythonIcon },
   { name: 'C' },
   { name: 'C++' },
-  { name: 'JavaScript', Icon: JavascriptIcon },
-  { name: 'TypeScript', Icon: TypeScriptIcon },
-  { name: 'Python', Icon: PythonIcon },
   { name: 'Java', Icon: JavaIcon },
   { name: 'Haskell', Icon: HaskellIcon },
   { name: 'Ruby', Icon: RubyIcon },
@@ -68,6 +69,7 @@ export const PROGRAMMING_LANGUAGES: Array<TechnologyCardProps> = [
 
 export const FRAMEWORKS_AND_TECHNOLOGIES: Array<TechnologyCardProps> = [
   { name: 'React', Icon: ReactIcon },
+  { name: 'Streamlit', Icon: StreamlitIcon },
   { name: 'Node.js', Icon: NodeIcon },
   { name: 'NestJS', Icon: NestJSIcon },
   { name: 'Ruby on Rails', Icon: RubyOnRailsIcon },


### PR DESCRIPTION
**Changes made**

1. **Add Streamlit** (src/constants/index.ts): added `SiStreamlit` import and inserted `Streamlit` as the second entry in `FRAMEWORKS_AND_TECHNOLOGIES`, right after React.

2. **Reorder languages** (src/constants/index.ts): moved `TypeScript` and `JavaScript` to the top of `PROGRAMMING_LANGUAGES` so the most relevant technologies appear first.

**Test plan**
- Verify the tech stack cards render in the new order (TS, JS, React, Streamlit first)
- Verify Streamlit icon appears correctly